### PR TITLE
Fix changelog range

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -19,8 +19,8 @@ else
     echo "Fetching commits since last tag."
 
     # We have many tags, fetch since last one
-    latest_tag=`git describe --tags`
-    previous_tag="$(git describe --abbrev=0 --tags $(git rev-list --tags --skip=1 --max-count=1))"
+    latest_tag=`git tag --sort=-creatordate | head -1`
+    previous_tag=`git tag --sort=-creatordate | head -2 | tail -1`
 
     # Get commit messages since previous tag
     changelog="$(git log --pretty=format:"$git_log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"


### PR DESCRIPTION
The current commands are pulling in [too many commits](https://github.com/alphaexplorationco/clubhouse_android/releases/tag/1.0.33-1011200) (commits before the two latest tags). My theory is that it's because according to `git describe --help`:
 > The command finds the most recent tag **that is reachable from a commit**.

`git tag` gives the most recently created tag in the entire repo.

Sample output from these changes:

```
- 19801f9f6: Prepare release 22.4.12 (GitHub Actions) (2022-04-12 23:06:01)
- 6be72c883: [ez] Add social proof to onboarding follow suggestions (#2168) (Mopewa Ogundipe) (2022-04-12 18:48:13)
- 20d02eb11: [Android][Bug] Make sure that screenshot is availble before checking the experiment (#2166) (maniclub) (2022-04-12 14:42:35)
- 5e10db158: [Ultravox] Update webrtc to M100 (#2163) (David Carr) (2022-04-12 17:12:42)
- 3fefb78fc: Create new Two Tap Wave Bar (#2151) (yipeiguan) (2022-04-12 14:06:20)
- 28f2104f0: Fix potential crash from missing activity intent (#2165) (Daniel Grech) (2022-04-13 06:00:19)
- 6fcb11f4b: [profile] Fix compacted bio being shown in expanded half profile (#2164) (Daniel Grech) (2022-04-13 05:34:59)
- 62b502419: [T-18617] Show self profile in tab UI (#2144) (Daniel Grech) (2022-04-13 04:27:46)
- b301342ee: [T-16021] Visual Refresh - tweak profile follow suggestions/notification option buttons (#2162) (Daniel Grech) (2022-04-13 04:03:17)
- a39a3ecca: [Ultravox] Handle becoming speaker, audio level, and mute updates (#2121) (David Carr) (2022-04-12 10:42:57)
- ea573f22a: [Social Clubs] Add a "Create new social club item" (#2160) (yipeiguan) (2022-04-12 09:19:02)
- ffe9519f8: [Android][UserPrompt] Show user prompt on every app startup (#2116) (maniclub) (2022-04-11 16:06:10)
- f556c9094: Add new Social Club List Fragment (#2157) (yipeiguan) (2022-04-11 13:43:50)
- facc63175: [Social Clubs] Create boiler plate API code for Social Clubs Module (#2156) (yipeiguan) (2022-04-11 13:38:27)
- da3ce65c2: [T-18617] Tab boilerplate (#2136) (Daniel Grech) (2022-04-12 04:55:01)
- d264bff81: Update visual refresh glyphs (#2158) (Daniel Grech) (2022-04-12 04:04:27)
- a85a99625: [Ez] Fix truncation issue with social proof (#2154) (Mopewa Ogundipe) (2022-04-11 13:21:02)
- 3c84fe240: [T-18617] Split up ClubhouseActivity (#2133) (Daniel Grech) (2022-04-09 16:01:22)
- 9d9d82001: Prevent empty arrays to crash Backchannel Crash (#2155) (yipeiguan) (2022-04-08 17:16:14)
- a06aef847: Optimistically remove myself as speaker (#2138) (yipeiguan) (2022-04-08 14:35:04)
- 597bdd790: Use push instead of pr for Bitrise trigger (#2149) (David Carr) (2022-04-08 13:35:12)
- 9954a2e2d: Add (optional) "Online Friends" notification setting (#2147) (Daniel Grech) (2022-04-09 05:00:58)
- 30a2adfdd: Remove redundant BundleUtil methods (#2143) (Daniel Grech) (2022-04-08 10:04:30)
- 6d2984ceb: Update follow/following button styling (#2137) (Daniel Grech) (2022-04-08 09:59:19)
- 6560f94ee: Prepare release 22.4.7 (#2142) (github-actions[bot]) (2022-04-07 16:15:22)
- 2ba915d49: Prepare release 22.4.7 (GitHub Actions) (2022-04-07 23:06:00)
```

