### PR TITLE
More changelog fixes

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -20,10 +20,9 @@ else
 
     # We have many tags, fetch since last one
     latest_tag=`git tag --sort=-creatordate | head -1`
-    previous_tag=`git tag --sort=-creatordate | head -2 | tail -1`
 
     # Get commit messages since previous tag
-    changelog="$(git log --pretty=format:"$git_log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag...$previous_tag)"
+    changelog="$(git log --pretty=format:"$git_log_format" --date=format:"%Y-%m-%d %H:%M:%S" $latest_tag..$HEAD)"
 fi
 
 # Add branch info
@@ -46,7 +45,6 @@ fi
 # Output collected information
 echo "Committer: $(git log --pretty=format:"%ce" HEAD^..HEAD)"
 echo "Latest tag: $latest_tag"
-echo "Previous tag: $previous_tag"
 echo "Changelog:"
 echo "$changelog"
 


### PR DESCRIPTION
My previous change here led to unexpected and incorrect [output](https://alphaexplorationco.slack.com/archives/C02R19A05TQ/p1649993588395399). Looked into it and realized that 
1) we don't tag release builds until after we gather the change log. So the method of looking at commits between the latest tag and previous tag would actually just give us changes from the last release
2) for nightly builds, we would also always just output the last release's changelog.

This updates our changelog to be changes from the latest commit on the current branch and the lastest repo tag. 